### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -17,6 +17,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7.1.1
+      - uses: release-drafter/release-drafter@v7.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[release-drafter/release-drafter](https://github.com/release-drafter/release-drafter)** published a new release **[v7.3.1](https://github.com/release-drafter/release-drafter/releases/tag/v7.3.1)** on 2026-05-25T09:26:22Z
