### PR TITLE
Derive guard name from user_type when retrieving the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ If you are using the PasswordlessLogin Trait, you can generate a link using the 
 
 The biggest mistake I could see someone making with this package is creating a login link for one user and sending it to another. Please be careful and test your code. I don't want anyone getting mad at me for someone else's silliness.
 
+### Multiple Guards
+
+If you have more than one user-type model authenticated on different guards (e.g. `User` on `web` and `Admin` on `admin`), override `getGuardNameAttribute()` on each model to return its own guard instead of the globally configured one:
+
+```php
+class Admin extends Authenticatable
+{
+    use PasswordlessLogin;
+
+    public function getGuardNameAttribute(): string
+    {
+        return 'admin';
+    }
+}
+```
+
+The package uses this to both retrieve and log in the user with the correct guard, so a link generated for an `Admin` is authenticated against the `admin` guard rather than `LPL_USER_GUARD`.
+
 ### Configuration
 You can publish the config file or just set the values you want to use in your .env file:
 ```dotenv

--- a/src/PasswordlessLoginService.php
+++ b/src/PasswordlessLoginService.php
@@ -38,7 +38,10 @@ class PasswordlessLoginService
             return null;
         }
 
-        return Auth::guard(config('laravel-passwordless-login.user_guard'))
+        $userClass = UserClass::fromSlug(request('user_type'));
+        $guard = (new $userClass)->guard_name ?? config('laravel-passwordless-login.user_guard');
+
+        return Auth::guard($guard)
             ->getProvider()
             ->retrieveById(request('uid'));
     }

--- a/tests/Fixtures/AdminUser.php
+++ b/tests/Fixtures/AdminUser.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use Grosv\LaravelPasswordlessLogin\Traits\PasswordlessLogin;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class AdminUser extends Authenticatable
+{
+    use PasswordlessLogin;
+
+    protected $table = 'admins';
+
+    protected $fillable = ['name', 'email', 'password'];
+
+    public function getGuardNameAttribute(): string
+    {
+        return 'admin';
+    }
+}

--- a/tests/MultipleGuardsTest.php
+++ b/tests/MultipleGuardsTest.php
@@ -6,7 +6,6 @@ use Faker\Factory as Faker;
 use Grosv\LaravelPasswordlessLogin\LoginUrl;
 use Grosv\LaravelPasswordlessLogin\Models\User;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;

--- a/tests/MultipleGuardsTest.php
+++ b/tests/MultipleGuardsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests;
+
+use Faker\Factory as Faker;
+use Grosv\LaravelPasswordlessLogin\LoginUrl;
+use Grosv\LaravelPasswordlessLogin\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Fixtures\AdminUser;
+
+class MultipleGuardsTest extends TestCase
+{
+    private $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('auth.guards.admin', ['driver' => 'session', 'provider' => 'admins']);
+        Config::set('auth.providers.admins', ['driver' => 'eloquent', 'model' => AdminUser::class]);
+
+        Schema::create('admins', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+
+        $faker = Faker::create();
+
+        // Deliberately create the web user first, so it shares its auto-increment id
+        // with the admin user created below. This proves the correct guard/table is
+        // used to retrieve the user rather than whichever "users" row has the same id.
+        $this->user = User::create([
+            'name' => $faker->name,
+            'email' => $faker->unique()->safeEmail,
+            'email_verified_at' => now(),
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'remember_token' => Str::random(10),
+        ]);
+
+        $this->admin = AdminUser::create([
+            'name' => $faker->name,
+            'email' => $faker->unique()->safeEmail,
+            'email_verified_at' => now(),
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'remember_token' => Str::random(10),
+        ]);
+    }
+
+    #[Test]
+    public function the_guard_configured_on_the_user_model_is_used_to_retrieve_the_user()
+    {
+        $this->assertSame($this->user->id, $this->admin->id);
+
+        $url = (new LoginUrl($this->admin))->generate();
+
+        $this->assertGuest('admin');
+        $this->assertGuest('web');
+
+        $this->get($url);
+
+        $this->assertAuthenticatedAs($this->admin, 'admin');
+        $this->assertGuest('web');
+    }
+
+    #[Test]
+    public function a_user_without_a_custom_guard_still_uses_the_default_guard()
+    {
+        $url = (new LoginUrl($this->user))->generate();
+
+        $this->assertGuest('web');
+
+        $this->followingRedirects()->get($url);
+
+        $this->assertAuthenticatedAs($this->user, 'web');
+        $this->assertGuest('admin');
+    }
+}


### PR DESCRIPTION
Replicates #68: 

PasswordlessLoginService::getUser() always looked up the user through the globally configured guard, even though LaravelPasswordlessLoginController already logs the user in via a per-model guard_name attribute. If a user model guard_name differs from the configured guard, the lookup now uses that guard provider instead.

Thanks to https://github.com/rico for the initial implementation.