### PR TITLE
Fix link invalidation

### DIFF
--- a/src/LoginUrl.php
+++ b/src/LoginUrl.php
@@ -38,7 +38,27 @@ class LoginUrl
             ]
         );
 
-        cache()->put(UserClass::cacheKey($this->user), true, $this->routeExpires);
+        // Keyed by expiry rather than a single boolean so a second link for the same
+        // user can't clobber an earlier, still-valid link's marker (see issue #140).
+        $key = UserClass::cacheKey($this->user);
+        $activeLinks = UserClass::activeLinks($key);
+
+        // Drop already-expired entries so this array doesn't grow unbounded for users
+        // who generate many links.
+        $activeLinks = array_filter(
+            $activeLinks,
+            fn (bool $active, int $expires): bool => $expires >= now()->timestamp, ARRAY_FILTER_USE_BOTH
+        );
+
+        $activeLinks[$this->routeExpires->timestamp] = true;
+
+        // TTL must cover the furthest-out link, not just this one, or a later
+        // short-lived link would prematurely evict an existing long-lived one.
+        cache()->put(
+            $key,
+            $activeLinks,
+            Carbon::createFromTimestamp(max(array_keys($activeLinks)))
+        );
 
         return $url;
     }

--- a/src/PasswordlessLoginService.php
+++ b/src/PasswordlessLoginService.php
@@ -2,6 +2,7 @@
 
 namespace Grosv\LaravelPasswordlessLogin;
 
+use Carbon\Carbon;
 use Grosv\LaravelPasswordlessLogin\Traits\PasswordlessLogin;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\Request;
@@ -12,14 +13,26 @@ use Illuminate\Support\Facades\Auth;
  */
 class PasswordlessLoginService
 {
-    private string $cacheKey;
-
     public ?Authenticatable $user;
 
     public function __construct()
     {
         $this->user = $this->getUser();
-        $this->cacheKey = request('user_type').request('uid');
+    }
+
+    private function cacheKey(): string
+    {
+        return request('user_type').request('uid');
+    }
+
+    private function expires(): int
+    {
+        return (int) request('expires');
+    }
+
+    private function activeLinks(): array
+    {
+        return UserClass::activeLinks($this->cacheKey());
     }
 
     /**
@@ -27,7 +40,7 @@ class PasswordlessLoginService
      */
     public function usesTrait(): bool
     {
-        $traits = class_uses($this->user, true);
+        $traits = class_uses_recursive($this->user);
 
         return in_array(PasswordlessLogin::class, $traits);
     }
@@ -57,13 +70,28 @@ class PasswordlessLoginService
             ? $this->user->login_use_once
             : config('laravel-passwordless-login.login_use_once');
 
-        if ($loginOnce) {
-            cache()->forget($this->cacheKey);
+        if (! $loginOnce) {
+            return;
         }
+
+        $activeLinks = $this->activeLinks();
+        unset($activeLinks[$this->expires()]);
+
+        if (empty($activeLinks)) {
+            cache()->forget($this->cacheKey());
+
+            return;
+        }
+
+        cache()->put(
+            $this->cacheKey(),
+            $activeLinks,
+            Carbon::createFromTimestamp(max(array_keys($activeLinks)))
+        );
     }
 
     public function requestIsNew(): bool
     {
-        return cache()->has($this->cacheKey);
+        return array_key_exists($this->expires(), $this->activeLinks());
     }
 }

--- a/src/UserClass.php
+++ b/src/UserClass.php
@@ -12,6 +12,14 @@ class UserClass
         return static::toSlug(get_class($user)).$user->getAuthIdentifier();
     }
 
+    // Pre-upgrade entries were a bare `true`; treat those as empty rather than erroring.
+    public static function activeLinks(string $key): array
+    {
+        $activeLinks = cache()->get($key, []);
+
+        return is_array($activeLinks) ? $activeLinks : [];
+    }
+
     public static function toSlug(string $class): string
     {
         $pieces = array_map(function (string $piece): string {

--- a/tests/SignedUrlTest.php
+++ b/tests/SignedUrlTest.php
@@ -243,4 +243,32 @@ class SignedUrlTest extends TestCase
         $this->assertAuthenticatedAs($this->user);
         Auth::logout();
     }
+
+    #[Test]
+    public function generating_a_second_link_does_not_invalidate_the_first()
+    {
+        // $this->url (from setUp) is the long-lived link; generate a short-lived second link.
+        $this->user->login_route_expires_in = 5;
+        (new LoginUrl($this->user))->generate();
+
+        $this->assertGuest();
+        $this->followingRedirects()->get($this->url);
+        $this->assertAuthenticatedAs($this->user);
+    }
+
+    #[Test]
+    public function consuming_a_use_once_link_does_not_invalidate_a_sibling_link()
+    {
+        Config::set('laravel-passwordless-login.login_use_once', true);
+
+        $this->user->login_route_expires_in = 60;
+        $second = (new LoginUrl($this->user))->generate();
+
+        $this->followingRedirects()->get($this->url);
+        $this->assertAuthenticatedAs($this->user);
+        Auth::logout();
+
+        $this->followingRedirects()->get($second);
+        $this->assertAuthenticatedAs($this->user);
+    }
 }


### PR DESCRIPTION
## Problem

Reported in #141. `LoginUrl::generate()` tracked link validity with a single boolean cache marker keyed only by user (`user_type` + `uid`):

```php
cache()->put(UserClass::cacheKey($this->user), true, $this->routeExpires);
```

Because the key doesn't reference the link itself, generating a second link for the same user overwrites the first link's marker with the new one's TTL. The older link's signature and `expires` are still valid and unexpired, but it fails with a 401 the moment a second link is issued for that user — e.g. a six-month link dies 30 minutes after a short-lived link is generated for the same user, per the repro in #140.

## Solution

Replace the single boolean marker with an array of active link expiries, still stored under the same per-user cache key:

- `LoginUrl::generate()` adds an entry keyed by the new link's `expires` timestamp instead of overwriting the whole cache entry, pruning already-expired entries so the array doesn't grow unbounded, and extends the cache TTL to cover the furthest-out active link.
- `PasswordlessLoginService::requestIsNew()` checks for the incoming request's own `expires` timestamp in that array, instead of just checking whether any marker exists for the user.
- `PasswordlessLoginService::consumeRequest()` (the `login_use_once` path) now removes only the consumed link's entry, rather than wiping every outstanding link for the user — fixing a related collateral-invalidation side effect of the old single-key design.
- `PasswordlessLoginManager::invalidateForUser()` is unchanged: it still `forget()`s the whole per-user key, so explicit invalidation continues to fail-closed and revoke every outstanding link at once.

The read/coerce logic (guarding against pre-upgrade cache entries that are a bare `true` rather than an array) is centralized in a new `UserClass::activeLinks()` static, used by both `LoginUrl` and `PasswordlessLoginService`.

Added two regression tests to `SignedUrlTest`: one confirming a second link doesn't invalidate the first, and one confirming that consuming a use-once link doesn't collaterally invalidate a sibling link for the same user.
