### PR TITLE
Make cache-marker requirement opt-in for link validity

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ LPL_LOGIN_ROUTE_EXPIRES=30
 LPL_REDIRECT_ON_LOGIN=/
 LPL_USER_GUARD=web
 LPL_USE_ONCE=false
+LPL_REQUIRE_CACHE_MARKER=false
 LPL_INVALID_SIGNATURE_MESSAGE="Expired or Invalid Link"
 ```
 `LPL_USER_MODEL` is the the authenticatable model you are logging in (usually App\Models\User)
@@ -116,6 +117,8 @@ LPL_INVALID_SIGNATURE_MESSAGE="Expired or Invalid Link"
 
 `LPL_USE_ONCE` is whether you want a link to expire after first use. When enabled, the link is consumed on first use and cannot be used again.
 
+`LPL_REQUIRE_CACHE_MARKER` is whether a link must have a matching entry in the cache to be considered valid, which is what powers [invalidating links](#invalidating-links) before they expire. It defaults to `false` so that links generated before you adopted this feature (or before you upgraded across a version that introduced it) keep working based on their own signature and expiry alone. Turn it on if you need `invalidateForUser()` to actually revoke outstanding multi-use links — note that doing so also means a cleared or evicted cache will invalidate every outstanding link, so make sure your cache store is durable enough for your link lifetimes before enabling it. `LPL_USE_ONCE` links always check the cache marker regardless of this setting.
+
 `LPL_INVALID_SIGNATURE_MESSAGE` is a custom message sent when we abort with a 401 status on an invalid or expired link. You can also add some custom logic on how to deal with invalid or expired links by handling `InvalidSignatureException` and `ExpiredSignatureException` in your `Handler.php` file.
 
 ### Invalidating Links
@@ -131,7 +134,7 @@ PasswordlessLogin::invalidateForUser($user);
 
 Generating a new link for a user automatically clears any prior invalidation, so calling `generate()` is all you need to issue a fresh link.
 
-> **Note:** Magic links are tracked in the cache. If your cache is cleared, any links generated before the flush will be treated as invalid. This is intentional — a cleared cache is safer than silently reactivating revoked links.
+> **Note:** `invalidateForUser()` only takes effect on multi-use links when `LPL_REQUIRE_CACHE_MARKER=true` (see [Configuration](#configuration)) — otherwise a link's own signature and expiry are all that's checked, and revocation is a no-op. With the marker required, magic links are tracked in the cache, so a cleared or evicted cache also invalidates every outstanding link — intentional, since a cleared cache is safer than silently reactivating a revoked link, but it means your cache store needs to be durable enough to outlive your longest-lived links. `LPL_USE_ONCE` links check the cache marker regardless of this setting, since consuming a link has always relied on it.
 
 ### Events
 

--- a/config/config.php
+++ b/config/config.php
@@ -12,6 +12,7 @@ return [
     'login_route_expires' => intval(env('LPL_LOGIN_ROUTE_EXPIRES', 30)),
     'redirect_on_success' => env('LPL_REDIRECT_ON_LOGIN', '/'),
     'login_use_once' => env('LPL_USE_ONCE', false),
+    'require_cache_marker' => env('LPL_REQUIRE_CACHE_MARKER', false),
     'invalid_signature_message' => env('LPL_INVALID_SIGNATURE_MESSAGE', ''),
     'middleware' => env('LPL_MIDDLEWARE', ['web', HandleAuthenticatedUsers::class]),
 ];

--- a/src/PasswordlessLoginService.php
+++ b/src/PasswordlessLoginService.php
@@ -35,6 +35,13 @@ class PasswordlessLoginService
         return UserClass::activeLinks($this->cacheKey());
     }
 
+    private function loginOnce(): bool
+    {
+        return $this->usesTrait()
+            ? $this->user->login_use_once
+            : config('laravel-passwordless-login.login_use_once');
+    }
+
     /**
      * Checks if this use class uses the PasswordlessLogable trait.
      */
@@ -66,11 +73,7 @@ class PasswordlessLoginService
 
     public function consumeRequest(): void
     {
-        $loginOnce = $this->usesTrait()
-            ? $this->user->login_use_once
-            : config('laravel-passwordless-login.login_use_once');
-
-        if (! $loginOnce) {
+        if (! $this->loginOnce()) {
             return;
         }
 
@@ -92,6 +95,10 @@ class PasswordlessLoginService
 
     public function requestIsNew(): bool
     {
+        if (! $this->loginOnce() && ! config('laravel-passwordless-login.require_cache_marker', false)) {
+            return true;
+        }
+
         return array_key_exists($this->expires(), $this->activeLinks());
     }
 }

--- a/tests/SignedUrlTest.php
+++ b/tests/SignedUrlTest.php
@@ -13,6 +13,7 @@ use Grosv\LaravelPasswordlessLogin\LoginUrl;
 use Grosv\LaravelPasswordlessLogin\Models\Models\User as ModelUser;
 use Grosv\LaravelPasswordlessLogin\Models\User;
 use Grosv\LaravelPasswordlessLogin\PasswordlessLogin;
+use Grosv\LaravelPasswordlessLogin\UserClass;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
@@ -184,6 +185,8 @@ class SignedUrlTest extends TestCase
     #[Test]
     public function a_link_invalidated_via_facade_cannot_be_used()
     {
+        Config::set('laravel-passwordless-login.require_cache_marker', true);
+
         PasswordlessLogin::invalidateForUser($this->user);
         $this->assertGuest();
 
@@ -198,6 +201,8 @@ class SignedUrlTest extends TestCase
     #[Test]
     public function generating_a_new_link_clears_invalidation()
     {
+        Config::set('laravel-passwordless-login.require_cache_marker', true);
+
         PasswordlessLogin::invalidateForUser($this->user);
         $this->url = (new LoginUrl($this->user))->generate();
 
@@ -270,5 +275,33 @@ class SignedUrlTest extends TestCase
 
         $this->followingRedirects()->get($second);
         $this->assertAuthenticatedAs($this->user);
+    }
+
+    #[Test]
+    public function a_link_with_no_cache_marker_still_works_by_default()
+    {
+        // Simulates a link generated before this package tracked markers in the cache
+        // (see issue #140) — its signature and expiry are valid, but no marker exists.
+        cache()->forget(UserClass::cacheKey($this->user));
+
+        $this->assertGuest();
+        $this->followingRedirects()->get($this->url);
+        $this->assertAuthenticatedAs($this->user);
+    }
+
+    #[Test]
+    public function a_link_with_no_cache_marker_is_rejected_when_marker_is_required()
+    {
+        Config::set('laravel-passwordless-login.require_cache_marker', true);
+
+        cache()->forget(UserClass::cacheKey($this->user));
+
+        $this->assertGuest();
+        $this->get($this->url);
+        $this->assertGuest();
+
+        $this->withoutExceptionHandling();
+        $this->expectException(InvalidSignatureException::class);
+        $this->get($this->url);
     }
 }


### PR DESCRIPTION
## Problem

Reported in #140 (point 1). 2.1.0 (#129, "Invalidate links") made a cache marker mandatory for a link to be considered valid:

```php
// PasswordlessLoginService::requestIsNew(), pre-fix
return cache()->has($this->cacheKey);
```

In 2.0.1, the equivalent check was `! $loginOnce || ! cache()->has($this->cacheKey)` — without `login_use_once`, the marker was never consulted at all; a link was valid purely by its signature and expiry. `LoginUrl::generate()` never wrote a marker before 2.1.0, so the moment an app upgrades, every link already in a user's inbox starts returning 401 — even though its signature and `expires` are untouched. There's no upgrade note, and the break is silent.

## Solution

Make marker-checking opt-in via a new config value, `laravel-passwordless-login.require_cache_marker` / env `LPL_REQUIRE_CACHE_MARKER`, defaulting to `false`:

- `PasswordlessLoginService::requestIsNew()` now returns `true` immediately when the link isn't `login_use_once` *and* the new flag is off — restoring exact 2.0.1 semantics. This means upgrading (from 2.0.x, or from an already-broken 2.1.x) is non-breaking by default, with zero config changes required.
- `login_use_once` links are unaffected — they already depended on the cache marker before 2.1.0, so that path still checks it regardless of the new flag.
- Extracted the existing trait-vs-config `login_use_once` ternary (previously duplicated) into a `loginOnce()` helper, used by both `consumeRequest()` and `requestIsNew()`.

**Trade-off, called out in the README:** with the flag off (the default), `PasswordlessLoginManager::invalidateForUser()` becomes a no-op for multi-use links, since `requestIsNew()` no longer consults the marker for them. Anyone relying on 2.1.0's revocation feature for multi-use links needs to set `LPL_REQUIRE_CACHE_MARKER=true` to keep it working — a small, deliberate, one-line opt-in rather than a silent break inflicted by `composer update`.

Two existing tests (`a_link_invalidated_via_facade_cannot_be_used`, `generating_a_new_link_clears_invalidation`) now explicitly enable the flag, since they test `invalidateForUser()` behavior. Added two new tests: one confirming a marker-less link (simulating a pre-2.1.0 or pre-this-fix link) still authenticates by default, and one confirming it's rejected once the flag is turned on.

Fixes #140 (point 1). Point 2 (cache durability / configurable store) from that issue is a separate concern and not addressed here.