### PR TITLE
Allow configuring a separate cache store for link markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ LPL_REDIRECT_ON_LOGIN=/
 LPL_USER_GUARD=web
 LPL_USE_ONCE=false
 LPL_REQUIRE_CACHE_MARKER=false
+LPL_CACHE_STORE=
 LPL_INVALID_SIGNATURE_MESSAGE="Expired or Invalid Link"
 ```
 `LPL_USER_MODEL` is the the authenticatable model you are logging in (usually App\Models\User)
@@ -119,6 +120,8 @@ LPL_INVALID_SIGNATURE_MESSAGE="Expired or Invalid Link"
 
 `LPL_REQUIRE_CACHE_MARKER` is whether a link must have a matching entry in the cache to be considered valid, which is what powers [invalidating links](#invalidating-links) before they expire. It defaults to `false` so that links generated before you adopted this feature (or before you upgraded across a version that introduced it) keep working based on their own signature and expiry alone. Turn it on if you need `invalidateForUser()` to actually revoke outstanding multi-use links — note that doing so also means a cleared or evicted cache will invalidate every outstanding link, so make sure your cache store is durable enough for your link lifetimes before enabling it. `LPL_USE_ONCE` links always check the cache marker regardless of this setting.
 
+`LPL_CACHE_STORE` is the name of the cache store (as defined in your `config/cache.php`) that link markers are read from and written to. Leave it blank to use your app's default (`cache.default`). Set it to point markers at a specific store when you need them to survive things that don't affect link validity — a `cache:clear` on deploy, a Redis restart, or `maxmemory` eviction on your general-purpose cache — which matters most once `LPL_REQUIRE_CACHE_MARKER=true`, since that's when marker survival determines whether a link still works.
+
 `LPL_INVALID_SIGNATURE_MESSAGE` is a custom message sent when we abort with a 401 status on an invalid or expired link. You can also add some custom logic on how to deal with invalid or expired links by handling `InvalidSignatureException` and `ExpiredSignatureException` in your `Handler.php` file.
 
 ### Invalidating Links
@@ -134,7 +137,7 @@ PasswordlessLogin::invalidateForUser($user);
 
 Generating a new link for a user automatically clears any prior invalidation, so calling `generate()` is all you need to issue a fresh link.
 
-> **Note:** `invalidateForUser()` only takes effect on multi-use links when `LPL_REQUIRE_CACHE_MARKER=true` (see [Configuration](#configuration)) — otherwise a link's own signature and expiry are all that's checked, and revocation is a no-op. With the marker required, magic links are tracked in the cache, so a cleared or evicted cache also invalidates every outstanding link — intentional, since a cleared cache is safer than silently reactivating a revoked link, but it means your cache store needs to be durable enough to outlive your longest-lived links. `LPL_USE_ONCE` links check the cache marker regardless of this setting, since consuming a link has always relied on it.
+> **Note:** `invalidateForUser()` only takes effect on multi-use links when `LPL_REQUIRE_CACHE_MARKER=true` (see [Configuration](#configuration)) — otherwise a link's own signature and expiry are all that's checked, and revocation is a no-op. With the marker required, magic links are tracked in the cache, so a cleared or evicted cache also invalidates every outstanding link — intentional, since a cleared cache is safer than silently reactivating a revoked link, but it means your cache store needs to be durable enough to outlive your longest-lived links. Use `LPL_CACHE_STORE` to point markers at a store dedicated to that purpose, separate from whatever your app flushes on deploy. `LPL_USE_ONCE` links check the cache marker regardless of this setting, since consuming a link has always relied on it.
 
 ### Events
 

--- a/config/config.php
+++ b/config/config.php
@@ -13,6 +13,7 @@ return [
     'redirect_on_success' => env('LPL_REDIRECT_ON_LOGIN', '/'),
     'login_use_once' => env('LPL_USE_ONCE', false),
     'require_cache_marker' => env('LPL_REQUIRE_CACHE_MARKER', false),
+    'cache_store' => env('LPL_CACHE_STORE'),
     'invalid_signature_message' => env('LPL_INVALID_SIGNATURE_MESSAGE', ''),
     'middleware' => env('LPL_MIDDLEWARE', ['web', HandleAuthenticatedUsers::class]),
 ];

--- a/src/LoginUrl.php
+++ b/src/LoginUrl.php
@@ -54,7 +54,7 @@ class LoginUrl
 
         // TTL must cover the furthest-out link, not just this one, or a later
         // short-lived link would prematurely evict an existing long-lived one.
-        cache()->put(
+        UserClass::store()->put(
             $key,
             $activeLinks,
             Carbon::createFromTimestamp(max(array_keys($activeLinks)))

--- a/src/PasswordlessLoginManager.php
+++ b/src/PasswordlessLoginManager.php
@@ -43,6 +43,6 @@ class PasswordlessLoginManager
 
     public function invalidateForUser(User $user): void
     {
-        cache()->forget(UserClass::cacheKey($user));
+        UserClass::store()->forget(UserClass::cacheKey($user));
     }
 }

--- a/src/PasswordlessLoginService.php
+++ b/src/PasswordlessLoginService.php
@@ -81,12 +81,12 @@ class PasswordlessLoginService
         unset($activeLinks[$this->expires()]);
 
         if (empty($activeLinks)) {
-            cache()->forget($this->cacheKey());
+            UserClass::store()->forget($this->cacheKey());
 
             return;
         }
 
-        cache()->put(
+        UserClass::store()->put(
             $this->cacheKey(),
             $activeLinks,
             Carbon::createFromTimestamp(max(array_keys($activeLinks)))

--- a/src/UserClass.php
+++ b/src/UserClass.php
@@ -3,6 +3,7 @@
 namespace Grosv\LaravelPasswordlessLogin;
 
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Support\Str;
 
 class UserClass
@@ -12,10 +13,17 @@ class UserClass
         return static::toSlug(get_class($user)).$user->getAuthIdentifier();
     }
 
+    // Lets link markers live in a store separate from cache.default (see issue #140),
+    // since a durable-enough store matters once require_cache_marker is enabled.
+    public static function store(): Repository
+    {
+        return cache()->store(config('laravel-passwordless-login.cache_store'));
+    }
+
     // Pre-upgrade entries were a bare `true`; treat those as empty rather than erroring.
     public static function activeLinks(string $key): array
     {
-        $activeLinks = cache()->get($key, []);
+        $activeLinks = static::store()->get($key, []);
 
         return is_array($activeLinks) ? $activeLinks : [];
     }

--- a/tests/SignedUrlTest.php
+++ b/tests/SignedUrlTest.php
@@ -304,4 +304,23 @@ class SignedUrlTest extends TestCase
         $this->expectException(InvalidSignatureException::class);
         $this->get($this->url);
     }
+
+    #[Test]
+    public function markers_are_written_to_the_configured_cache_store_not_the_default()
+    {
+        Config::set('cache.stores.default_test_store', ['driver' => 'array']);
+        Config::set('cache.default', 'default_test_store');
+        Config::set('cache.stores.markers', ['driver' => 'array']);
+        Config::set('laravel-passwordless-login.cache_store', 'markers');
+
+        $key = UserClass::cacheKey($this->user);
+        $this->url = (new LoginUrl($this->user))->generate();
+
+        $this->assertTrue(cache()->store('markers')->has($key));
+        $this->assertFalse(cache()->store('default_test_store')->has($key));
+
+        $this->assertGuest();
+        $this->followingRedirects()->get($this->url);
+        $this->assertAuthenticatedAs($this->user);
+    }
 }


### PR DESCRIPTION
## Problem

Reported in #140 (point 2). Link markers are read from and written to `cache.default` — whatever cache store the app uses for everything else. Any `php artisan cache:clear` (common on deploy), a Redis restart without persistence, or `maxmemory` eviction drops the markers, independent of a link's own signature and expiry. That's harmless for short links, but the reporter issues links with lifetimes up to six months via their API, and those markers need to survive routine app-cache churn.

This is only relevant once `LPL_REQUIRE_CACHE_MARKER=true` (#143) — with it off (the default), markers aren't consulted for multi-use links at all, so durability doesn't matter. But anyone opting in for `invalidateForUser()` needs marker survival independent of the general-purpose cache lifecycle.

## Solution

Add `laravel-passwordless-login.cache_store` / env `LPL_CACHE_STORE`, defaulting to unset (`null`, meaning "use `cache.default`" — fully backward compatible).

- `UserClass::store()` is the single place that resolves `cache()->store(config('laravel-passwordless-login.cache_store'))`. Every marker read/write in the package (`LoginUrl::generate()`, `UserClass::activeLinks()`, `PasswordlessLoginManager::invalidateForUser()`, `PasswordlessLoginService::consumeRequest()`) now goes through it instead of the bare `cache()` helper, so the configured store is used consistently everywhere.

Added a test that defines two separate `array`-driver stores at runtime and confirms markers land in the one configured via `LPL_CACHE_STORE`, not `cache.default`. README documents the new setting and cross-references it from the existing durability caveat in the "Invalidating Links" section.

Fixes #140 (point 2). This is the last of the three points raised in that issue.